### PR TITLE
当日目撃のfast pathで編成の最新目撃キャッシュを検証し同一編成の重複運用を防ぐ

### DIFF
--- a/src/libs/operation-sighting/usecase/operation-sighting.v3.service.spec.ts
+++ b/src/libs/operation-sighting/usecase/operation-sighting.v3.service.spec.ts
@@ -297,6 +297,13 @@ describe('OperationSightingV3Service - findOneTimeCrossSectionByOperationNumber'
         };
         mockOperationSightingQuery.findOneLatestByOperationNumberAndBeforeSightingTime.mockResolvedValue(latestSighting);
         mockCalendarQuery.findOneBySpecificDate.mockResolvedValue({ id: 'cal-1', startDate: '2026-03-13' });
+        mockOperationSightingLatestCacheQuery.findOneByFormationNumber.mockResolvedValue({
+            id: 'cache-1',
+            operationSightingId: 'sighting-1',
+            operationNumber: '65',
+            formationNumber: '8001',
+            sightingTime: '2026-05-30T10:00:00.000+09:00',
+        });
 
         const result = await service.findOneTimeCrossSectionByOperationNumber({
             operationNumber: '65',
@@ -308,6 +315,32 @@ describe('OperationSightingV3Service - findOneTimeCrossSectionByOperationNumber'
         expect(
             mockOperationSightingLatestCacheQuery.findManyLatestGroupByFormationByOperationNumbersAndSightingTimeRange,
         ).not.toHaveBeenCalled();
+    });
+
+    it('当日の目撃があっても、その後その編成が別運用で目撃されていた場合は expectedSighting: null を返す', async () => {
+        const latestSighting = {
+            id: 'sighting-1',
+            operation: { operationNumber: '65' },
+            formation: { formationNumber: '8001' },
+            sightingTime: '2026-05-30T10:00:00.000+09:00',
+        };
+        mockOperationSightingQuery.findOneLatestByOperationNumberAndBeforeSightingTime.mockResolvedValue(latestSighting);
+        mockCalendarQuery.findOneBySpecificDate.mockResolvedValue({ id: 'cal-1', startDate: '2026-03-13' });
+        mockOperationSightingLatestCacheQuery.findOneByFormationNumber.mockResolvedValue({
+            id: 'cache-1',
+            operationSightingId: 'sighting-2',
+            operationNumber: '66',
+            formationNumber: '8001',
+            sightingTime: '2026-05-30T11:00:00.000+09:00',
+        });
+
+        const result = await service.findOneTimeCrossSectionByOperationNumber({
+            operationNumber: '65',
+            searchTime: '2026-05-30T15:00:00+09:00',
+        });
+
+        expect(result.latestSighting).toBe(latestSighting);
+        expect(result.expectedSighting).toBeNull();
     });
 
     it('calendar が null の場合は expectedSighting: null を返す', async () => {

--- a/src/libs/operation-sighting/usecase/operation-sighting.v3.service.ts
+++ b/src/libs/operation-sighting/usecase/operation-sighting.v3.service.ts
@@ -86,13 +86,19 @@ export class OperationSightingV3Service {
         );
 
         if (searchBaseDate.isSame(latestSightingBaseDate)) {
-            // 当日の目撃があればキャッシュ検索不要。その編成をそのまま返す
             const { operation, formation } = latestSighting;
-            return {
-                latestSighting,
-                expectedSighting:
-                    operation && formation ? { operation, formation } : null,
-            };
+            if (!operation || !formation) {
+                return { latestSighting, expectedSighting: null };
+            }
+            // 編成の最新目撃キャッシュが別運用を指している場合、この編成は追い出されている
+            const formationLatestCache =
+                await this.operationSightingLatestCacheQuery.findOneByFormationNumber(
+                    { formationNumber: formation.formationNumber },
+                );
+            if (!formationLatestCache || formationLatestCache.operationNumber !== operationNumber) {
+                return { latestSighting, expectedSighting: null };
+            }
+            return { latestSighting, expectedSighting: { operation, formation } };
         }
 
         if (!calendar) {


### PR DESCRIPTION
同一編成が複数運用に同時表示されるバグを修正する。
findOneTimeCrossSectionByOperationNumberの当日判定パスで、
編成の最新目撃キャッシュ（formationLatestCache）を参照し、
operationNumberが一致しない場合はexpectedSighting: nullを返すよう修正する。