### PR TITLE
編成番号側fast pathで運用の最新目撃を検証し追い出し済み編成の重複表示を防ぐ

### DIFF
--- a/src/libs/operation-sighting/usecase/operation-sighting.v3.service.spec.ts
+++ b/src/libs/operation-sighting/usecase/operation-sighting.v3.service.spec.ts
@@ -482,6 +482,7 @@ describe('OperationSightingV3Service - findOneTimeCrossSectionByFormationNumber'
         };
         mockOperationSightingQuery.findOneLatestByFormationNumberAndBeforeSightingTime.mockResolvedValue(latestSighting);
         mockCalendarQuery.findOneBySpecificDate.mockResolvedValue({ id: 'cal-1', startDate: '2026-03-13' });
+        mockOperationSightingQuery.findOneLatestByOperationNumberAndBeforeSightingTime.mockResolvedValue(latestSighting);
 
         const result = await service.findOneTimeCrossSectionByFormationNumber({
             formationNumber: '8001',
@@ -492,6 +493,31 @@ describe('OperationSightingV3Service - findOneTimeCrossSectionByFormationNumber'
         expect(
             mockOperationSightingLatestCacheQuery.findManyLatestGroupByFormationByOperationNumbersAndSightingTimeRange,
         ).not.toHaveBeenCalled();
+    });
+
+    it('当日の目撃があっても、その後その運用に別編成が目撃されていた場合は expectedSighting: null を返す', async () => {
+        const latestSighting = {
+            id: 'sighting-1',
+            operation: { id: 'op-38K', operationNumber: '38K' },
+            formation: { id: 'f-3109', formationNumber: '3109' },
+            sightingTime: '2026-05-30T10:00:00.000+09:00',
+        };
+        mockOperationSightingQuery.findOneLatestByFormationNumberAndBeforeSightingTime.mockResolvedValue(latestSighting);
+        mockCalendarQuery.findOneBySpecificDate.mockResolvedValue({ id: 'cal-1', startDate: '2026-03-13' });
+        mockOperationSightingQuery.findOneLatestByOperationNumberAndBeforeSightingTime.mockResolvedValue({
+            id: 'sighting-2',
+            operation: { id: 'op-38K', operationNumber: '38K' },
+            formation: { id: 'f-3104', formationNumber: '3104' },
+            sightingTime: '2026-05-30T11:00:00.000+09:00',
+        });
+
+        const result = await service.findOneTimeCrossSectionByFormationNumber({
+            formationNumber: '3109',
+            searchTime: '2026-05-30T15:00:00+09:00',
+        });
+
+        expect(result.latestSighting).toBe(latestSighting);
+        expect(result.expectedSighting).toBeNull();
     });
 
     it('最新目撃が休車（100番）の場合は operation をそのまま返す', async () => {

--- a/src/libs/operation-sighting/usecase/operation-sighting.v3.service.ts
+++ b/src/libs/operation-sighting/usecase/operation-sighting.v3.service.ts
@@ -168,13 +168,19 @@ export class OperationSightingV3Service {
         );
 
         if (searchBaseDate.isSame(latestSightingBaseDate)) {
-            // 当日の目撃があれば循環不要。その運用番号をそのまま返す
             const { operation, formation } = latestSighting;
-            return {
-                latestSighting,
-                expectedSighting:
-                    operation && formation ? { operation, formation } : null,
-            };
+            if (!operation || !formation) {
+                return { latestSighting, expectedSighting: null };
+            }
+            // その運用のより新しい目撃が別編成によるものなら、この編成は追い出されている
+            const operationLatestCache =
+                await this.operationSightingQuery.findOneLatestByOperationNumberAndBeforeSightingTime(
+                    { operationNumber: operation.operationNumber, sightingTime: searchTimeInstance },
+                );
+            if (operationLatestCache?.formation?.formationNumber !== formation.formationNumber) {
+                return { latestSighting, expectedSighting: null };
+            }
+            return { latestSighting, expectedSighting: { operation, formation } };
         }
 
         const latestOperation = latestSighting.operation;


### PR DESCRIPTION
編成番号検索の当日判定パスで、運用の最新目撃キャッシュ（operationLatestCache）を参照し、 別編成によるものならexpectedSighting: nullを返すよう修正する。
（例: 3109が38Kで目撃後に3104が38Kで目撃された場合、3109の38K表示を抑制する）